### PR TITLE
修复self.user['token']不存在问题

### DIFF
--- a/baidupcsapi/api.py
+++ b/baidupcsapi/api.py
@@ -245,6 +245,7 @@ class PCSBase(object):
                 logging.debug(str(cookies))
                 self.session.cookies = cookies
                 self.user['BDUSS'] = self.session.cookies['BDUSS']
+                self.user['token'] = self._get_token()
                 return True
         else:
             return False


### PR DESCRIPTION
通过加载cookie文件完成登陆，但是没有设置user['token']字段，导致发送请求时报KeyError错误。
通过在load_cookies()中添加`self.user['token'] = self._get_token()`进行修复
关联issue #64 